### PR TITLE
🐛 fix: add `attestation` field to oracle client

### DIFF
--- a/packages/clients/lib/oracle/client.ts
+++ b/packages/clients/lib/oracle/client.ts
@@ -21,6 +21,7 @@ export interface Announcement {
   eventId: string;
   offerId: string;
   announcement: string;
+  attestation?: string;
   cso: boolean;
   startDate: number;
   endDate: number;


### PR DESCRIPTION
## What

Add `attestation` field in Announcement type