### PR TITLE
🐛 fix: network error on react-native

### DIFF
--- a/packages/clients/lib/oracle/client.ts
+++ b/packages/clients/lib/oracle/client.ts
@@ -116,7 +116,7 @@ export class OracleClient {
       timeout: 20000,
       method,
       params,
-      data,
+      data: method === 'GET' ? undefined : data,
       responseType: 'json',
     };
 

--- a/packages/clients/lib/strategy/client.ts
+++ b/packages/clients/lib/strategy/client.ts
@@ -117,7 +117,7 @@ export class StrategyClient {
       timeout: 20000,
       method,
       params,
-      data,
+      data: method === 'GET' ? undefined : data,
       responseType: 'json',
     };
 


### PR DESCRIPTION
## What

For some reason, axios fails on React Native when the `data` parameter is not set to undefined on GET requests.

This PR sets the data field to undefined for GET requests.