### PR TITLE
🐛 fix: switch start date params from cso event id

### DIFF
--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -372,9 +372,14 @@ describe('CSO utilities', () => {
             'monthly',
           ] as const;
 
-          const { tradingOpen, tradingOpenHalfMonth, upcomingDlcExpiry } =
-            getCsoEventDates(atMaturity);
           const {
+            newEntryClosed,
+            tradingOpen,
+            tradingOpenHalfMonth,
+            upcomingDlcExpiry,
+          } = getCsoEventDates(atMaturity);
+          const {
+            newEntryClosed: nextNewEntryClosed,
             tradingOpen: nextTradingOpen,
             upcomingDlcExpiry: nextDlcExpiry,
           } = getCsoEventDates(nextMaturity);
@@ -417,7 +422,9 @@ describe('CSO utilities', () => {
           expect(upcomingDlcExpiry.getUTCHours()).to.equal(8);
 
           // atomic-call_spread_v1-monthly-27JUN22-29JUL22
-          expect(startDateFirstMonth.getTime()).to.equal(tradingOpen.getTime());
+          expect(startDateFirstMonth.getTime()).to.equal(
+            newEntryClosed.getTime(),
+          );
           expect(endDateFirstMonth.getTime()).to.equal(
             upcomingDlcExpiry.getTime(),
           );
@@ -432,7 +439,7 @@ describe('CSO utilities', () => {
 
           // atomic-call_spread_v1-monthly-1AUG22-26AUG22
           expect(startDateSecondMonth.getTime()).to.equal(
-            nextTradingOpen.getTime(),
+            nextNewEntryClosed.getTime(),
           );
           expect(endDateSecondMonth.getTime()).to.equal(
             nextDlcExpiry.getTime(),
@@ -482,9 +489,9 @@ describe('CSO utilities', () => {
       it('should extract correct date for trading open', () => {
         const dateStr = '30JAN23';
         const date = extractCsoEventIdDateFromStr(dateStr);
-        const { tradingOpen } = getCsoEventDates(date);
+        const { newEntryClosed } = getCsoEventDates(date);
 
-        expect(date.getTime()).to.equal(tradingOpen.getTime());
+        expect(date.getTime()).to.equal(newEntryClosed.getTime());
       });
 
       it('should extract correct date for dlc expiry', () => {

--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -375,6 +375,7 @@ describe('CSO utilities', () => {
           const {
             newEntryClosed,
             tradingOpen,
+            halfMonthEntryClosed,
             tradingOpenHalfMonth,
             upcomingDlcExpiry,
           } = getCsoEventDates(atMaturity);
@@ -431,7 +432,7 @@ describe('CSO utilities', () => {
 
           // atomic-call_spread_v1-monthly-15JUL22-29JUL22
           expect(startDateHalfMonth.getTime()).to.equal(
-            tradingOpenHalfMonth.getTime(),
+            halfMonthEntryClosed.getTime(),
           );
           expect(endDateHalfMonth.getTime()).to.equal(
             upcomingDlcExpiry.getTime(),

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -308,6 +308,8 @@ export const getParamsFromCsoEventId = (eventId: string): CsoParams => {
 export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
   const [, day, month, year] = dateStr.match(STR_DATE_REGEX);
 
+  // Set date to 12 PM UTC since it is between DLC Expiry and DLC Attestation
+  // and also after Trading Open and Trading Open Half Month
   const date = new Date(`${month}-${day}-${year} 12:00:00 GMT`);
 
   const csoEvent = getCsoEvent(date);
@@ -323,9 +325,8 @@ export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
   if (csoEvent === 'tradingOpen') {
     if (date.getUTCDate() === tradingOpen.getUTCDate()) return newEntryClosed;
   } else if (csoEvent === 'tradingOpenHalfMonth') {
-    if (date.getUTCDate() === halfMonthEntryClosed.getUTCDate()) {
-      return tradingOpenHalfMonth;
-    }
+    if (date.getUTCDate() === tradingOpenHalfMonth.getUTCDate())
+      return halfMonthEntryClosed;
   } else if (csoEvent === 'dlcExpiry') {
     if (date.getUTCDate() === upcomingDlcExpiry.getUTCDate()) {
       return upcomingDlcExpiry;

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -313,6 +313,7 @@ export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
   const csoEvent = getCsoEvent(date);
   const {
     previousDlcExpiry,
+    newEntryClosed,
     tradingOpen,
     halfMonthEntryClosed,
     tradingOpenHalfMonth,
@@ -320,7 +321,7 @@ export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
   } = getCsoEventDates(date);
 
   if (csoEvent === 'tradingOpen') {
-    if (date.getUTCDate() === tradingOpen.getUTCDate()) return tradingOpen;
+    if (date.getUTCDate() === tradingOpen.getUTCDate()) return newEntryClosed;
   } else if (csoEvent === 'tradingOpenHalfMonth') {
     if (date.getUTCDate() === halfMonthEntryClosed.getUTCDate()) {
       return tradingOpenHalfMonth;


### PR DESCRIPTION
## What

Switch `tradingOpen` to `newEntryClosed` for start date from `getParamsFromCsoEventId`

Fixes https://github.com/AtomicFinance/atomic-utils/issues/16