### PR TITLE
🐛 fix: switch half month return for extract cso

### DIFF
--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -432,7 +432,7 @@ describe('CSO utilities', () => {
 
           // atomic-call_spread_v1-monthly-15JUL22-29JUL22
           expect(startDateHalfMonth.getTime()).to.equal(
-            halfMonthEntryClosed.getTime(),
+            tradingOpenHalfMonth.getTime(),
           );
           expect(endDateHalfMonth.getTime()).to.equal(
             upcomingDlcExpiry.getTime(),

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -319,7 +319,6 @@ export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
     previousDlcExpiry,
     newEntryClosed,
     tradingOpen,
-    halfMonthEntryClosed,
     tradingOpenHalfMonth,
     upcomingDlcExpiry,
   } = getCsoEventDates(date);
@@ -328,7 +327,7 @@ export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
     if (date.getUTCDate() === tradingOpen.getUTCDate()) return newEntryClosed;
   } else if (csoEvent === 'tradingOpenHalfMonth') {
     if (date.getUTCDate() === tradingOpenHalfMonth.getUTCDate())
-      return halfMonthEntryClosed;
+      return tradingOpenHalfMonth;
   } else if (csoEvent === 'dlcExpiry') {
     if (date.getUTCDate() === upcomingDlcExpiry.getUTCDate()) {
       return upcomingDlcExpiry;


### PR DESCRIPTION
## What

Switch `extractCsoEventIdDateFromStr` for half month from `halfMonthEntryClosed` to `tradingOpenHalfMonth` since `startDate` should not include expiry trade from previous half of month

## Why

We ran into an edge case where the expiry trade at 8 am UTC was included in list of trades, which should not occur. 