### PR TITLE
🥅 catch: add validation for milliseconds

### DIFF
--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -131,6 +131,26 @@ describe('CSO utilities', () => {
           );
         });
       }
+
+      it('should fail if seconds provided', () => {
+        const timestampInSeconds = Math.floor(lastFridays[0].getTime() / 1000);
+        const t = new Date(timestampInSeconds);
+
+        expect(() => getCurrentCycleMaturityDate(t)).to.throw(
+          Error,
+          `Invalid date provided ${t} with timestamp ${t.getTime()}, you may have used seconds instead of milliseconds`,
+        );
+      });
+
+      it('should fail if microseconds provided', () => {
+        const timestampInMicroSeconds = lastFridays[0].getTime() * 1000;
+        const t = new Date(timestampInMicroSeconds);
+
+        expect(() => getCurrentCycleMaturityDate(t)).to.throw(
+          Error,
+          `Invalid date provided ${t} with timestamp ${t.getTime()}, you may have used microseconds instead of milliseconds`,
+        );
+      });
     });
 
     describe('getNextCycleMaturityDate', () => {

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -20,6 +20,7 @@ export const HALF_MONTH_ENTRY_CLOSED_LEN = 6;
 export const TRADING_OPEN_HALF_MONTH_LEN = 334;
 
 import { getStrDate } from '@atomic-utils/deribit';
+import assert from 'assert';
 
 export const STR_DATE_REGEX = /(\d{1,2})([A-Z]+)(\d{1,2})/;
 
@@ -53,6 +54,15 @@ export const getCurrentCycleMaturityDate = (t_: Date): Date => {
   const t = new Date(t_.getTime()); // clone to avoid mutation
 
   let y = t.getUTCFullYear();
+  assert(
+    y >= 2009,
+    `Invalid date provided ${t} with timestamp ${t.getTime()}, you may have used seconds instead of milliseconds`,
+  );
+  assert(
+    y <= 2100,
+    `Invalid date provided ${t} with timestamp ${t.getTime()}, you may have used microseconds instead of milliseconds`,
+  );
+
   let m = t.getUTCMonth() + 1;
   let lastFriday = getLastFridayInMonth(y, m);
 

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -55,11 +55,11 @@ export const getCurrentCycleMaturityDate = (t_: Date): Date => {
 
   let y = t.getUTCFullYear();
   assert(
-    y >= 2009,
+    y >= 2009, // since cycle maturity cannot be before Bitcoin was created
     `Invalid date provided ${t} with timestamp ${t.getTime()}, you may have used seconds instead of milliseconds`,
   );
   assert(
-    y <= 2100,
+    y <= 2100, // reasonable upper bound
     `Invalid date provided ${t} with timestamp ${t.getTime()}, you may have used microseconds instead of milliseconds`,
   );
 


### PR DESCRIPTION
## What

Add validation for milliseconds to `getCurrentCycleMaturityDate`

## Why

To ensure user of lib doesn’t accidentally pass microseconds or milliseconds