### PR TITLE
🐛 fix: get last friday in month utc day

### DIFF
--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -36,10 +36,10 @@ export const STR_DATE_REGEX = /(\d{1,2})([A-Z]+)(\d{1,2})/;
  */
 export const getLastFridayInMonth = (y: number, m: number): Date => {
   const lastDay = new Date(Date.UTC(y, m, 0, 8, 0, 0));
-  if (lastDay.getDay() < 5) {
+  if (lastDay.getUTCDay() < 5) {
     lastDay.setDate(lastDay.getDate() - 7);
   }
-  lastDay.setDate(lastDay.getDate() - (lastDay.getDay() - 5));
+  lastDay.setDate(lastDay.getDate() - (lastDay.getUTCDay() - 5));
 
   return lastDay;
 };


### PR DESCRIPTION
## What

Fix timeonze issue with getting last friday in month utc

We should’ve been calling `getUTCDay` instead of `getDay`

## Anything Else

To reproduce, switch to Alaskan timezone