### PR TITLE
🐛 fix: local string bug and ensure en-US is used

### DIFF
--- a/packages/deribit/lib/index.ts
+++ b/packages/deribit/lib/index.ts
@@ -11,7 +11,7 @@ export const getStrDate = (date: number | Date): string => {
 
   const day = date.getUTCDate();
   const month = date
-    .toLocaleString('default', { month: 'short', timeZone: 'UTC' })
+    .toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
     .toUpperCase()
     .replace('.', '');
   const year = date.toLocaleDateString('pl', {


### PR DESCRIPTION
## What

Fix local string bug and ensure `en-US` is used

## Anything Else

When user local currency was chinese `getStrDate` was returning `2511月22` from deribit utils. This fixes that issue. 