### PR TITLE
✨ feat: create cso events 1.5 months

### DIFF
--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -10,6 +10,7 @@ import {
   getCsoEvent,
   getCsoEventDates,
   getCsoEventId,
+  getCsoStartAndEndDate,
   getCurrentCycleMaturityDate,
   getLastFridayInMonth,
   getNextCycleMaturityDate,
@@ -688,6 +689,70 @@ describe('CSO utilities', () => {
 
         expect(isHalfMonth(halfCycleEventId)).to.equal(true);
         expect(isHalfMonth(fullCycleEventId)).to.equal(false);
+      });
+    });
+
+    describe('getCsoStartAndEndDate', () => {
+      const beforeHalfMonth = new Date(Date.UTC(2023, 6, 4));
+
+      const provider = 'atomic';
+      const strategyId = 'call_spread_v1';
+      const period = 'monthly';
+
+      it('should calculate properly for one and a half month', () => {
+        const { startDate, endDate } = getCsoStartAndEndDate(
+          beforeHalfMonth,
+          true,
+        );
+
+        const eventId = getCsoEventId(
+          beforeHalfMonth,
+          provider,
+          strategyId,
+          period,
+          true,
+        );
+
+        const params = getParamsFromCsoEventId(eventId);
+
+        const expectedStartDate = new Date(Date.UTC(2023, 6, 14, 4)); // half month entry close
+        const expectedParamsStart = new Date(Date.UTC(2023, 6, 14, 10)); // half month trading start
+        const expectedEndDate = new Date(Date.UTC(2023, 7, 25, 8));
+
+        expect(startDate.getTime()).to.equal(expectedStartDate.getTime());
+        expect(endDate.getTime()).to.equal(expectedEndDate.getTime());
+
+        expect(params.startDate.getTime()).to.equal(
+          expectedParamsStart.getTime(),
+        );
+        expect(params.endDate.getTime()).to.equal(expectedEndDate.getTime());
+      });
+
+      it('should calculate properly for half month', () => {
+        const { startDate, endDate } = getCsoStartAndEndDate(
+          beforeHalfMonth,
+          false,
+        );
+
+        const eventId = getCsoEventId(
+          beforeHalfMonth,
+          provider,
+          strategyId,
+          period,
+          false,
+        );
+
+        const params = getParamsFromCsoEventId(eventId);
+
+        const expectedStartDate = new Date(Date.UTC(2023, 6, 14, 4));
+        const expectedParamsStart = new Date(Date.UTC(2023, 6, 14, 10)); // half month trading start
+        const expectedEndDate = new Date(Date.UTC(2023, 6, 28, 8));
+
+        expect(startDate.getTime()).to.equal(expectedStartDate.getTime());
+        expect(endDate.getTime()).to.equal(expectedEndDate.getTime());
+        expect(params.startDate.getTime()).to.equal(
+          expectedParamsStart.getTime(),
+        );
       });
     });
   });

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -202,7 +202,10 @@ export const getCsoEvent = (t_: Date): CsoEvent => {
  * @param t_ current time
  * @returns {StartEndDates} start and end dates of the CSO event
  */
-export const getCsoStartAndEndDate = (t_: Date): StartEndDates => {
+export const getCsoStartAndEndDate = (
+  t_: Date,
+  forceExtendedPeriod = false,
+): StartEndDates => {
   const t = new Date(t_.getTime());
 
   const csoEvent = getCsoEvent(t);
@@ -227,10 +230,14 @@ export const getCsoStartAndEndDate = (t_: Date): StartEndDates => {
       endDate: nextDlcExpiry,
     };
   } else if (csoEvent === 'newEntryClosed' || csoEvent === 'tradingOpen') {
+    const { upcomingDlcExpiry: followingDlcExpiry } = getCsoEventDates(
+      new Date(upcomingDlcExpiry.getTime() + 1),
+    );
+
     // Create half month event ID
     return {
       startDate: halfMonthEntryClosed,
-      endDate: upcomingDlcExpiry,
+      endDate: forceExtendedPeriod ? followingDlcExpiry : upcomingDlcExpiry,
     };
   } else {
     // Create full month for current month
@@ -279,10 +286,11 @@ export const getCsoEventId = (
   provider: string,
   strategyId: string,
   period: CsoPeriod,
+  forceExtendedPeriod = false,
 ): string => {
   const t = new Date(t_.getTime());
 
-  const { startDate, endDate } = getCsoStartAndEndDate(t);
+  const { startDate, endDate } = getCsoStartAndEndDate(t, forceExtendedPeriod);
 
   return [
     provider,


### PR DESCRIPTION
## What

Add the ability to create CSO events that are 1.5 months in length by passing a flag

## Why

If a user is entering for half a month, they might spend a significant amount on fees. It's better to have them enter for a month and a half. 