### PR TITLE
🐛 fix: getPreviousFriday a few mins after maturity

### DIFF
--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -49,6 +49,7 @@ describe('CSO utilities', () => {
     rightBefore: new Date(Date.UTC(2022, 5, 24, 7, 59, 59, 0)), // dlcExpiry
     atMaturity: new Date(Date.UTC(2022, 5, 24, 8, 0, 0, 0)), // dlcExpiry
     rightAfter: new Date(Date.UTC(2022, 5, 24, 8, 0, 0, 1)),
+    minuteAfter: new Date(Date.UTC(2022, 5, 24, 8, 1, 0, 0)),
     sevenHoursAfter: new Date(Date.UTC(2022, 5, 24, 15, 0, 0, 0)), // dlcAttestation
     eightHoursAfter: new Date(Date.UTC(2022, 5, 24, 16, 0, 0, 0)), // rolloverOpen
     oneDayAfter: new Date(Date.UTC(2022, 5, 25, 8, 0, 0, 0)),
@@ -72,6 +73,7 @@ describe('CSO utilities', () => {
     rightBefore: new Date(Date.UTC(2022, 11, 30, 7, 59, 59, 0)),
     atMaturity: new Date(Date.UTC(2022, 11, 30, 8, 0, 0, 0)), // dlcExpiry
     rightAfter: new Date(Date.UTC(2022, 11, 30, 8, 0, 0, 1)),
+    minuteAfter: new Date(Date.UTC(2022, 11, 30, 8, 1, 0, 0)),
     sevenHoursAfter: new Date(Date.UTC(2022, 11, 30, 15, 0, 0, 0)), // dlcAttestation
     eightHoursAfter: new Date(Date.UTC(2022, 11, 30, 16, 0, 0, 0)), // rolloverOpen
     oneDayAfter: new Date(Date.UTC(2022, 11, 31, 8, 0, 0, 0)),
@@ -147,6 +149,7 @@ describe('CSO utilities', () => {
         weekBeforeMaturity,
         atMaturity,
         rightAfter,
+        minuteAfter,
         sevenHoursAfter,
         seventySixHoursAfter,
         oneWeekAfter,
@@ -154,16 +157,22 @@ describe('CSO utilities', () => {
       } = i === 0 ? midYearDates : endYearDates;
 
       it(`should get previous friday for cycle period ${period}`, () => {
+        const friFromMaturity = getPreviousFriday(atMaturity);
         const friFromRightAfter = getPreviousFriday(rightAfter);
+        const friFromMinuteAfter = getPreviousFriday(minuteAfter);
         const friFromSevenHoursAfter = getPreviousFriday(sevenHoursAfter);
         const friFromSeventySixHoursAfter =
           getPreviousFriday(seventySixHoursAfter);
         const friFromOneWeekAfter = getPreviousFriday(oneWeekAfter);
         const friFromTwoWeeksAfter = getPreviousFriday(twoWeeksAfter);
 
+        expect(friFromMaturity.getTime()).to.equal(
+          weekBeforeMaturity.getTime(),
+        );
         expect(friFromRightAfter.getTime()).to.equal(
           weekBeforeMaturity.getTime(),
         );
+        expect(friFromMinuteAfter.getTime()).to.equal(atMaturity.getTime());
         expect(friFromSevenHoursAfter.getTime()).to.equal(atMaturity.getTime());
         expect(friFromSeventySixHoursAfter.getTime()).to.equal(
           atMaturity.getTime(),

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -287,7 +287,14 @@ export const getPreviousFriday = (t_: Date): Date => {
   const t = new Date(t_.getTime());
   let dayDelta = (5 - t.getUTCDay() + 7) % 7;
 
-  if (dayDelta === 0 && t.getUTCHours() > 8) {
+  if (
+    dayDelta === 0 &&
+    (t.getUTCHours() > 8 ||
+      (t.getUTCHours() === 8 &&
+        t.getUTCMinutes() === 0 &&
+        t.getUTCSeconds() > 0) ||
+      (t.getUTCHours() === 8 && t.getUTCMinutes() > 0))
+  ) {
     dayDelta = 7;
   }
 


### PR DESCRIPTION
## What

Fix issue with getting previous friday with `getPreviousFriday` being called a few minutes after maturity

Due to the nature of the logic, it would previously go to the previous week, when it should simply go back a few minutes

This PR fixes that

## Anything Else

Added tests to test this edge case