### PR TITLE
feat: add force extended period for monthly eventIds

### DIFF
--- a/packages/time/__tests__/time-utils/cso-utils.spec.ts
+++ b/packages/time/__tests__/time-utils/cso-utils.spec.ts
@@ -742,6 +742,7 @@ describe('CSO utilities', () => {
 
     describe('getCsoStartAndEndDate', () => {
       const beforeHalfMonth = new Date(Date.UTC(2023, 6, 4));
+      const beforeFullMonth = new Date(Date.UTC(2023, 6, 18));
 
       const provider = 'atomic';
       const strategyId = 'call_spread_v1';
@@ -801,6 +802,35 @@ describe('CSO utilities', () => {
         expect(params.startDate.getTime()).to.equal(
           expectedParamsStart.getTime(),
         );
+      });
+
+      it('should calculate properly for two months', () => {
+        const { startDate, endDate } = getCsoStartAndEndDate(
+          beforeFullMonth,
+          true,
+        );
+
+        const eventId = getCsoEventId(
+          beforeFullMonth,
+          provider,
+          strategyId,
+          period,
+          true,
+        );
+
+        const params = getParamsFromCsoEventId(eventId);
+
+        const expectedStartDate = new Date(Date.UTC(2023, 6, 31, 4)); // full month trading start
+        const expectedParamsStart = new Date(Date.UTC(2023, 6, 31, 4)); // full month trading start
+        const expectedEndDate = new Date(Date.UTC(2023, 8, 29, 8));
+
+        expect(startDate.getTime()).to.equal(expectedStartDate.getTime());
+        expect(endDate.getTime()).to.equal(expectedEndDate.getTime());
+
+        expect(params.startDate.getTime()).to.equal(
+          expectedParamsStart.getTime(),
+        );
+        expect(params.endDate.getTime()).to.equal(expectedEndDate.getTime());
       });
     });
 

--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -217,6 +217,10 @@ export const getCsoStartAndEndDate = (
   const { newEntryClosed, halfMonthEntryClosed, upcomingDlcExpiry } =
     getCsoEventDates(t);
 
+  const { upcomingDlcExpiry: followingDlcExpiry } = getCsoEventDates(
+    new Date(upcomingDlcExpiry.getTime() + 1),
+  );
+
   if (
     csoEvent === 'halfMonthEntryClosed' ||
     csoEvent === 'tradingOpenHalfMonth'
@@ -229,15 +233,15 @@ export const getCsoStartAndEndDate = (
       upcomingDlcExpiry: nextDlcExpiry,
     } = getCsoEventDates(nextT);
 
-    return {
-      startDate: nextNewEntryClosed,
-      endDate: nextDlcExpiry,
-    };
-  } else if (csoEvent === 'newEntryClosed' || csoEvent === 'tradingOpen') {
     const { upcomingDlcExpiry: followingDlcExpiry } = getCsoEventDates(
-      new Date(upcomingDlcExpiry.getTime() + 1),
+      new Date(nextDlcExpiry.getTime() + 1),
     );
 
+    return {
+      startDate: nextNewEntryClosed,
+      endDate: forceExtendedPeriod ? followingDlcExpiry : nextDlcExpiry,
+    };
+  } else if (csoEvent === 'newEntryClosed' || csoEvent === 'tradingOpen') {
     // Create half month event ID
     return {
       startDate: halfMonthEntryClosed,
@@ -247,7 +251,7 @@ export const getCsoStartAndEndDate = (
     // Create full month for current month
     return {
       startDate: newEntryClosed,
-      endDate: upcomingDlcExpiry,
+      endDate: forceExtendedPeriod ? followingDlcExpiry : upcomingDlcExpiry,
     };
   }
 };


### PR DESCRIPTION
## What

Modify the existing functionality of `getCsoStartAndEndDate` so that `forceExtendedPeriod` also modifies the default length of monthly event ids as well. 

Previously `forceExtendedPeriod` would only convert half-month event ids to month-and-a-half event ids. Now it also extends monthly event ids to two-month long event ids

## Why

With greater on-chain tx fees, it's necessary to have longer DLC lengths to reduce network fees. Defaulting to 2 month / month-and-a-half long DLCs helps with this