### PR TITLE
fix: timezone issue cso event id parse react native

### DIFF
--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -27,6 +27,7 @@ export const TRADING_OPEN_HALF_MONTH_LEN = 334;
 
 import { getStrDate } from '@atomic-utils/deribit';
 import assert from 'assert';
+import moment from 'moment-timezone';
 
 export const STR_DATE_REGEX = /(\d{1,2})([A-Z]+)(\d{1,2})/;
 
@@ -567,9 +568,12 @@ export const getEventIdType = (eventId: string): CsoEventIdType | 'manual' => {
 export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
   const [, day, month, year] = dateStr.match(STR_DATE_REGEX);
 
+  // Use moment-timezone to parse the date string and set it to 12 PM UTC
   // Set date to 12 PM UTC since it is between DLC Expiry and DLC Attestation
   // and also after Trading Open and Trading Open Half Month
-  const date = new Date(`${month}-${day}-${year} 12:00:00 GMT`);
+  const date = moment
+    .tz(`${day} ${month} ${year} 12:00:00`, 'DD MMM YY HH:mm:ss', 'UTC')
+    .toDate();
 
   const csoEvent = getCsoEvent(date);
   const {

--- a/packages/time/package-lock.json
+++ b/packages/time/package-lock.json
@@ -450,6 +450,19 @@
 				"mime-db": "1.52.0"
 			}
 		},
+		"moment": {
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
+		},
+		"moment-timezone": {
+			"version": "0.5.45",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+			"integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+			"requires": {
+				"moment": "^2.29.4"
+			}
+		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@atomic-utils/deribit": "^0.4.3",
-    "@sentry/node": "6.16.1"
+    "@sentry/node": "6.16.1",
+    "moment-timezone": "0.5.45"
   },
   "devDependencies": {
     "sentry-testkit": "3.3.7",


### PR DESCRIPTION
## What

Fix timezone issue cso event id parsing for react native

## Why

Timezone-related discrepancy in date handling between environments. React Native's JavaScript runtime is different from Node.js