### PR TITLE
fix: edge case timezone issue

### DIFF
--- a/packages/time/lib/cso.ts
+++ b/packages/time/lib/cso.ts
@@ -596,10 +596,6 @@ export const extractCsoEventIdDateFromStr = (dateStr: string): Date => {
     }
   } else if (csoEvent === 'newEntryClosed') {
     return newEntryClosed;
-  } else {
-    throw Error(
-      `eventId dateStr invalid and likely on rollover weekend. CsoEvent: ${csoEvent}`,
-    );
   }
   return date;
 };


### PR DESCRIPTION
## What

Fix issue with `extractCsoEventIdDateFromStr` function where certain timezone edge cases, particularly on react native, can result in error being thrown

Since this is primarily used for extracting proper date for UI, we should just default to date provided. 