### PR TITLE
dep-up: @node-dlc 1.1.2

### DIFF
--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/atomicfinance/atomic-utils.git"
   },
   "dependencies": {
-    "@node-dlc/logger": "1.1.1",
+    "@node-dlc/logger": "1.1.2",
     "axios": "0.27.2"
   },
   "devDependencies": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -24,9 +24,9 @@
 	},
 	"dependencies": {
 		"@atomic-utils/format": "^0.6.1",
-		"@node-dlc/core": "1.1.0",
-		"@node-dlc/logger": "1.1.0",
-		"@node-dlc/messaging": "1.1.0"
+		"@node-dlc/core": "1.1.2",
+		"@node-dlc/logger": "1.1.2",
+		"@node-dlc/messaging": "1.1.2"
 	},
 	"devDependencies": {
 		"@types/node": "^18.19.123",

--- a/packages/deribit/package.json
+++ b/packages/deribit/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@atomic-utils/format": "^0.6.1",
-    "@node-dlc/core": "1.1.1",
-    "@node-dlc/logger": "1.1.1",
-    "@node-dlc/messaging": "1.1.1"
+    "@node-dlc/core": "1.1.2",
+    "@node-dlc/logger": "1.1.2",
+    "@node-dlc/messaging": "1.1.2"
   },
   "devDependencies": {
     "@types/node": "^18.19.123",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/atomicfinance/atomic-utils.git"
   },
   "dependencies": {
-    "@node-dlc/logger": "1.1.1",
+    "@node-dlc/logger": "1.1.2",
     "@sentry/node": "6.16.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
   packages/clients:
     dependencies:
       '@node-dlc/logger':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.1.2
+        version: 1.1.2
       axios:
         specifier: 0.27.2
         version: 0.27.2
@@ -121,17 +121,17 @@ importers:
   packages/contract:
     dependencies:
       '@atomic-utils/format':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.1
+        version: 0.6.1
       '@node-dlc/core':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.1.2
+        version: 1.1.2
       '@node-dlc/logger':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.1.2
+        version: 1.1.2
       '@node-dlc/messaging':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.1.2
+        version: 1.1.2
     devDependencies:
       '@types/node':
         specifier: ^18.19.123
@@ -146,17 +146,17 @@ importers:
   packages/deribit:
     dependencies:
       '@atomic-utils/format':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.1
+        version: 0.6.1
       '@node-dlc/core':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.1.2
+        version: 1.1.2
       '@node-dlc/logger':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.1.2
+        version: 1.1.2
       '@node-dlc/messaging':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.1.2
+        version: 1.1.2
     devDependencies:
       '@types/node':
         specifier: ^18.19.123
@@ -187,8 +187,8 @@ importers:
   packages/logger:
     dependencies:
       '@node-dlc/logger':
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 1.1.2
+        version: 1.1.2
       '@sentry/node':
         specifier: 6.16.1
         version: 6.16.1
@@ -203,8 +203,8 @@ importers:
   packages/time:
     dependencies:
       '@atomic-utils/deribit':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.1
+        version: 0.6.1
       moment-timezone:
         specifier: 0.5.45
         version: 0.5.45
@@ -225,11 +225,11 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@atomic-utils/deribit@0.6.0':
-    resolution: {integrity: sha512-CmOn+IgqL7Gvijxw/KLqSmrPiOBGE0n6tbX+lj7GbEiEJMXd6GaSf2h672jTBN8JF8sgI2h7J71Bd22UsklQuA==}
+  '@atomic-utils/deribit@0.6.1':
+    resolution: {integrity: sha512-OxDvKKVypRJ2YJMq3q2yQ49YVNDK5E8TYUPp1cbKZmaEwatuHDUPyivqAVDDe9XLlzA7I4S/zEIYcHaOqeXfSw==}
 
-  '@atomic-utils/format@0.6.0':
-    resolution: {integrity: sha512-67Kaf+GfYyxUBIWeHhNS134ybJXVqblsK5ptpUcNCPo9Fn2ZZ+aCeZMb1qmD0dObJRrVY6BpBSqGZ5IJImV/8g==}
+  '@atomic-utils/format@0.6.1':
+    resolution: {integrity: sha512-qeFTwkBpfKVzEMPXAHjCR9s9GkyG8xDrp4a/zW+v3nOjHr1R6zKAYoC0pJ4AHZ+TNm1q+0WbzrpPwilCroUtag==}
 
   '@babel/code-frame@7.12.11':
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
@@ -666,67 +666,67 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@node-dlc/bitcoin@1.1.0':
-    resolution: {integrity: sha512-kbHif5lkliuuK1IbLxH+Y+pQ0AxPVn8nDKsPQoMLa0wvHeA1rsf6WNNebBy0jEdht4M3Btj9rEwooCKeA2TdLQ==}
-
   '@node-dlc/bitcoin@1.1.1':
     resolution: {integrity: sha512-UmTkGnmsSs2Zi+lH/HbUlcZmJ33FkDeQ5JUb7f09BdFSxY5LgneZrKf+JLNusR74ePZ+wTsezrsBFRiQoFY9Kg==}
 
-  '@node-dlc/bufio@1.1.0':
-    resolution: {integrity: sha512-3qoCLNUB5ZXkmMsEHibYN+V2QpYVe7HrZPWN/yEIMKvbiAVVK4i9bDdGekWbnPBt0qtypbpby3MT6wqptpufOg==}
+  '@node-dlc/bitcoin@1.1.2':
+    resolution: {integrity: sha512-1fhykoqCutyUSVrKezi9dE2FHnv0VxNu7URoSKM9gPfay6jzan9JK5EToSoM45m2zJVLglnPNtn3xJLHRGwqpw==}
 
   '@node-dlc/bufio@1.1.1':
     resolution: {integrity: sha512-oKJGc8TUsTG+KuPcfp1NrxYMAati5xT41CcHo56GEL2SS5HLBV/xegzBhOIfd33dOfH9QoHZPjVSqE6MZ6YsGg==}
 
-  '@node-dlc/checksum@1.1.0':
-    resolution: {integrity: sha512-oWoSVkursXdIdua7sVlZDV/7RedhlXu0CtKDcNcNOCrCWOfz1QiuGab7eAIn8p5L7sLS+jymLLh8ZlTexRqrlQ==}
+  '@node-dlc/bufio@1.1.2':
+    resolution: {integrity: sha512-0BwL7Dd4wBYNPTIS9WXNDHvv4uO5ZR4/gYR7jpE2ad7OBUhSnIsJVZCNMgXa9GzXYj50iOQNs3C9TgwfKUU5fw==}
 
   '@node-dlc/checksum@1.1.1':
     resolution: {integrity: sha512-M6ZnL7MsEwEwLtCc1fd7IFNS/Q/M0jnMANQnqMCysAoQR8FfrVwObHwO2SzMeqlfc1bH1/I67w52yaGP3WvywA==}
 
-  '@node-dlc/common@1.1.0':
-    resolution: {integrity: sha512-64mMepx1F2pfJA+GqyMTuX+45eaafA68z713vUdyBx9CKmRwcSA5YKa8VFUOmhPA6DQUjKDAFRVfTUTYanpu3g==}
+  '@node-dlc/checksum@1.1.2':
+    resolution: {integrity: sha512-Ukc6O84ClnoaC7zD9HZV4xrxF3xB42SfrIGfWB+87PJPx8sEx57fIGcDtgx/vaxjhaWODC/W87MXEJZk1/Gqmw==}
 
   '@node-dlc/common@1.1.1':
     resolution: {integrity: sha512-aTcFMHSUWk9s3pe6CSf2wE5Pm6A6DoOCMuwhA/CqizTg+pcbhE0Bh9dI8CqKvucjLgdH/1L9gyFwvABIVH8e+g==}
 
-  '@node-dlc/core@1.1.0':
-    resolution: {integrity: sha512-Nau61w1IPdnnlLvgX2JjmZyQ3+bnUyKn7cP03bdj9aaNHcC3nblKMyC8Man4q5q1RTYz/oYt/i3X0Ee2oeWZOw==}
+  '@node-dlc/common@1.1.2':
+    resolution: {integrity: sha512-K0epIHjlXU/1U2NpNPja72DeIgJLdEDJoN0Jz+RBZIitgFOWELcsrl3oxry4X0y7bo91dnXYQ6lgtPU61RT+2Q==}
 
   '@node-dlc/core@1.1.1':
     resolution: {integrity: sha512-ve8yQttVO7ai2Ve6WX/f2NAPV24Iln9y2wKSDEYsHoPR5kMPrRQ3n6yADBp0zTQpM8Ths9TJMwiBeaOCIw8xgw==}
 
-  '@node-dlc/crypto@1.1.0':
-    resolution: {integrity: sha512-w4HmTDpB4uc0dviCH0sk7kmH3wZ1qwzvV7bxFum5oves5PQPvn6npHQu5h9KbySmAJxIBsM7sUfKulvMLE52BQ==}
-    engines: {node: '>=10.17'}
+  '@node-dlc/core@1.1.2':
+    resolution: {integrity: sha512-hzhi8wMh4LDTw2/WvfTup0DWdi5I3yA4tP9Lv6/APBp12g55I5knO638Esh8YXiPqOXvyCR1zvYeiaZizXoXdg==}
 
   '@node-dlc/crypto@1.1.1':
     resolution: {integrity: sha512-HiWXxsF1zLtepvS3cYeX+CVJHT/WxU6UDd/IkmbzmcMRUhHedyAaHq7PiaOA5B2QSyANNm41Sb3f618vy5mdjA==}
     engines: {node: '>=10.17'}
 
-  '@node-dlc/logger@1.1.0':
-    resolution: {integrity: sha512-Jv24jq6iiW0NUx2Cmj8ro9EBv84Ed5WPqzpdydmTshBiaGP3SkEsu2IFtbPQHOiiMsYs5+Xr4SJtI75W1tXoqQ==}
+  '@node-dlc/crypto@1.1.2':
+    resolution: {integrity: sha512-4AB41J+67NTQ/HR8k4tp7ZUdf3TUMFcfLRqjAma5vEWSAR1TNKnxciOuEmDmGewb2Tf6fkWIEAZw51zAty6bHA==}
+    engines: {node: '>=10.17'}
 
   '@node-dlc/logger@1.1.1':
     resolution: {integrity: sha512-z3QBN+Ct5nSVt+uTPNC3IZ2lP0P33OP3N1m3HRD1MevnZhdtcqtf672l2tU4UP9vMdiwe4r6dj8jyjgPJ4GuXw==}
 
-  '@node-dlc/messaging@1.1.0':
-    resolution: {integrity: sha512-YHZ5+qflSFHu4tksYKUq5nB9YpSphXBXlWKu1TAsf2oie53dGACoW6zYRGuu0Hloh2SlBFLC1UwGx9FS94+dww==}
+  '@node-dlc/logger@1.1.2':
+    resolution: {integrity: sha512-kxUYqv1O7N4Kbp4zb8i1chqp2msN0Pq+lSao+EPrsPg247xRWN8ZRj7VB4m8zfVrveIHtaSlCfULYyO0j7M7Hg==}
 
   '@node-dlc/messaging@1.1.1':
     resolution: {integrity: sha512-wv2sV49AYE3A+OG7mMVc5AWjasBMp/alE1jyv6/EWiLd2g2qe5cuDhr+MCb3fhLjnD97Bwy4iIUxYTg6i9Yk2A==}
 
-  '@node-dlc/noise@1.1.0':
-    resolution: {integrity: sha512-wbavo6eMEpRiEqPwYqskLWpMO8LR9LPgQzazBv/hSA/fvAsXyLRqgB6qBNxYi4HohUxtyFDVYpDEy+LZAfeLXw==}
+  '@node-dlc/messaging@1.1.2':
+    resolution: {integrity: sha512-pwbOVWHTCEd0j24NP2Nlc421qcp3AHAd6fGNPT4Gf+/aeMJVajVQZTjwENJmusYltD8osB9pCxC6XVdY0EQnBA==}
 
   '@node-dlc/noise@1.1.1':
     resolution: {integrity: sha512-TrP+kRMh3b0R/A1iQ/N9Mv8e9GFO0XB6vSrJGgvKlHOPxLfV6kg4rC4kem+/bVzlLzfBjGrTPuiKmeuDp76Ytg==}
 
-  '@node-dlc/wire@1.1.0':
-    resolution: {integrity: sha512-oPl2CBy1oJjbgdbtf5jpaolE72MJ5vvZZs08MXJZ1U6Mp3dSzu53VY7MTdqSrpZ50sNvvf8mWxKf41lNAY0sEQ==}
+  '@node-dlc/noise@1.1.2':
+    resolution: {integrity: sha512-dUdyE9/UDqIPsePMucb1waJV8l/W8DWI/AmNhkFJWfIc6BwggJanhdhDLDZrpz2Tb7Hy1ezJbgglF/F0a+84VQ==}
 
   '@node-dlc/wire@1.1.1':
     resolution: {integrity: sha512-hzQ8Kli5wJxR9pmFIWafbO3ZlU5IFT8T3lCNLsnB9kJkItcBc1DgbQf2v4e6NK+T/LjortrRPSuNmmwxFE6Pyg==}
+
+  '@node-dlc/wire@1.1.2':
+    resolution: {integrity: sha512-gvHd56GLSKgcV6XtKTjutNxxqKGWxLuefIUC7yuu1orTDYzTU3fyY19+4VJE5XIv1rO3aSomiq+EGJ/DOxgzmw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1209,10 +1209,6 @@ packages:
 
   bip-schnorr@0.6.3:
     resolution: {integrity: sha512-aScZ6wkbhxki/WhVghCPUTT0Uwar9FJ0tpFPhj5LcyFhtuFDsLvb0uNvwEVAVMBe8pHdjfNMvylBjksPdorRhA==}
-    engines: {node: '>=8.0.0'}
-
-  bip174@2.0.1:
-    resolution: {integrity: sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==}
     engines: {node: '>=8.0.0'}
 
   bip174@2.1.1:
@@ -4306,14 +4302,14 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
-  '@atomic-utils/deribit@0.6.0':
+  '@atomic-utils/deribit@0.6.1':
     dependencies:
-      '@atomic-utils/format': 0.6.0
-      '@node-dlc/core': 1.1.0
-      '@node-dlc/logger': 1.1.0
-      '@node-dlc/messaging': 1.1.0
+      '@atomic-utils/format': 0.6.1
+      '@node-dlc/core': 1.1.1
+      '@node-dlc/logger': 1.1.1
+      '@node-dlc/messaging': 1.1.1
 
-  '@atomic-utils/format@0.6.0':
+  '@atomic-utils/format@0.6.1':
     dependencies:
       bignumber.js: 9.3.1
 
@@ -5019,48 +5015,37 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@node-dlc/bitcoin@1.1.0':
-    dependencies:
-      '@node-dlc/bufio': 1.1.0
-      '@node-dlc/crypto': 1.1.0
-
   '@node-dlc/bitcoin@1.1.1':
     dependencies:
       '@node-dlc/bufio': 1.1.1
       '@node-dlc/crypto': 1.1.1
 
-  '@node-dlc/bufio@1.1.0':
+  '@node-dlc/bitcoin@1.1.2':
     dependencies:
-      decimal.js: 10.4.3
+      '@node-dlc/bufio': 1.1.2
+      '@node-dlc/crypto': 1.1.2
 
   '@node-dlc/bufio@1.1.1':
     dependencies:
       decimal.js: 10.4.3
 
-  '@node-dlc/checksum@1.1.0': {}
+  '@node-dlc/bufio@1.1.2':
+    dependencies:
+      decimal.js: 10.4.3
 
   '@node-dlc/checksum@1.1.1': {}
 
-  '@node-dlc/common@1.1.0':
-    dependencies:
-      '@node-dlc/bitcoin': 1.1.0
-      '@node-dlc/bufio': 1.1.0
+  '@node-dlc/checksum@1.1.2': {}
 
   '@node-dlc/common@1.1.1':
     dependencies:
       '@node-dlc/bitcoin': 1.1.1
       '@node-dlc/bufio': 1.1.1
 
-  '@node-dlc/core@1.1.0':
+  '@node-dlc/common@1.1.2':
     dependencies:
-      '@node-dlc/bitcoin': 1.1.0
-      '@node-dlc/bufio': 1.1.0
-      '@node-dlc/common': 1.1.0
-      '@node-dlc/crypto': 1.1.0
-      '@node-dlc/messaging': 1.1.0
-      bignumber.js: 9.3.1
-      bitcoin-networks: 1.0.0
-      decimal.js: 10.4.3
+      '@node-dlc/bitcoin': 1.1.2
+      '@node-dlc/bufio': 1.1.2
 
   '@node-dlc/core@1.1.1':
     dependencies:
@@ -5068,38 +5053,33 @@ snapshots:
       '@node-dlc/bufio': 1.1.1
       '@node-dlc/common': 1.1.1
       '@node-dlc/crypto': 1.1.1
-      '@node-dlc/messaging': 1.1.1
+      '@node-dlc/messaging': 1.1.2
       bignumber.js: 9.3.1
       bitcoin-networks: 1.0.0
       decimal.js: 10.4.3
 
-  '@node-dlc/crypto@1.1.0':
+  '@node-dlc/core@1.1.2':
     dependencies:
-      secp256k1: 4.0.4
+      '@node-dlc/bitcoin': 1.1.2
+      '@node-dlc/bufio': 1.1.2
+      '@node-dlc/common': 1.1.2
+      '@node-dlc/crypto': 1.1.2
+      '@node-dlc/messaging': 1.1.2
+      bignumber.js: 9.3.1
+      bitcoin-networks: 1.0.0
+      decimal.js: 10.4.3
 
   '@node-dlc/crypto@1.1.1':
     dependencies:
       secp256k1: 4.0.4
 
-  '@node-dlc/logger@1.1.0': {}
+  '@node-dlc/crypto@1.1.2':
+    dependencies:
+      secp256k1: 4.0.4
 
   '@node-dlc/logger@1.1.1': {}
 
-  '@node-dlc/messaging@1.1.0':
-    dependencies:
-      '@node-dlc/bitcoin': 1.1.0
-      '@node-dlc/bufio': 1.1.0
-      '@node-dlc/checksum': 1.1.0
-      '@node-dlc/common': 1.1.0
-      '@node-dlc/crypto': 1.1.0
-      '@node-dlc/wire': 1.1.0
-      '@types/json-bigint': 1.0.4
-      bip-schnorr: 0.6.3
-      bitcoin-networks: 1.0.0
-      bitcoinjs-lib: 6.1.7
-      decimal.js: 10.4.3
-      json-bigint: 1.0.0
-      secp256k1: 4.0.4
+  '@node-dlc/logger@1.1.2': {}
 
   '@node-dlc/messaging@1.1.1':
     dependencies:
@@ -5117,25 +5097,31 @@ snapshots:
       json-bigint: 1.0.0
       secp256k1: 4.0.4
 
-  '@node-dlc/noise@1.1.0':
+  '@node-dlc/messaging@1.1.2':
     dependencies:
-      '@node-dlc/crypto': 1.1.0
-      '@node-dlc/logger': 1.1.1
+      '@node-dlc/bitcoin': 1.1.2
+      '@node-dlc/bufio': 1.1.2
+      '@node-dlc/checksum': 1.1.2
+      '@node-dlc/common': 1.1.2
+      '@node-dlc/crypto': 1.1.2
+      '@node-dlc/wire': 1.1.2
+      '@types/json-bigint': 1.0.4
+      bip-schnorr: 0.6.3
+      bitcoin-networks: 1.0.0
+      bitcoinjs-lib: 6.1.7
+      decimal.js: 10.4.3
+      json-bigint: 1.0.0
+      secp256k1: 4.0.4
 
   '@node-dlc/noise@1.1.1':
     dependencies:
       '@node-dlc/crypto': 1.1.1
-      '@node-dlc/logger': 1.1.1
+      '@node-dlc/logger': 1.1.2
 
-  '@node-dlc/wire@1.1.0':
+  '@node-dlc/noise@1.1.2':
     dependencies:
-      '@node-dlc/bitcoin': 1.1.0
-      '@node-dlc/bufio': 1.1.0
-      '@node-dlc/checksum': 1.1.0
-      '@node-dlc/common': 1.1.0
-      '@node-dlc/crypto': 1.1.0
-      '@node-dlc/logger': 1.1.1
-      '@node-dlc/noise': 1.1.0
+      '@node-dlc/crypto': 1.1.2
+      '@node-dlc/logger': 1.1.2
 
   '@node-dlc/wire@1.1.1':
     dependencies:
@@ -5144,8 +5130,18 @@ snapshots:
       '@node-dlc/checksum': 1.1.1
       '@node-dlc/common': 1.1.1
       '@node-dlc/crypto': 1.1.1
-      '@node-dlc/logger': 1.1.1
+      '@node-dlc/logger': 1.1.2
       '@node-dlc/noise': 1.1.1
+
+  '@node-dlc/wire@1.1.2':
+    dependencies:
+      '@node-dlc/bitcoin': 1.1.2
+      '@node-dlc/bufio': 1.1.2
+      '@node-dlc/checksum': 1.1.2
+      '@node-dlc/common': 1.1.2
+      '@node-dlc/crypto': 1.1.2
+      '@node-dlc/logger': 1.1.2
+      '@node-dlc/noise': 1.1.2
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5703,8 +5699,6 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
-  bip174@2.0.1: {}
-
   bip174@2.1.1: {}
 
   bip32@2.0.6:
@@ -5730,7 +5724,7 @@ snapshots:
   bitcoinjs-lib@5.2.0:
     dependencies:
       bech32: 1.1.4
-      bip174: 2.0.1
+      bip174: 2.1.1
       bip32: 2.0.6
       bip66: 1.1.5
       bitcoin-ops: 1.4.1


### PR DESCRIPTION
## What

Bump @node-dlc to 1.1.2

## Why

1.1.2 fixes react native buffer compatibility issues

https://github.com/AtomicFinance/node-dlc/pull/231